### PR TITLE
Update 220224

### DIFF
--- a/xbzu1/1.0/board.xml
+++ b/xbzu1/1.0/board.xml
@@ -386,10 +386,6 @@
       <!-- MikroE Click UART -->
       <component name="click_uart_pl" display_name="PL Click UART" type="chip" sub_type="uart" major_group="Click" part_name="Click" vendor="MikroE">
         <description>PL Click UART</description>
-        <pins>
-            <pin index="0" name="USB_uart_TX" iostandard="LVCMOS33"/>
-            <pin index="1" name="USB_uart_RX" iostandard="LVCMOS33"/>
-        </pins>
       </component>
 
       <!-- PUSH BUTTON -->

--- a/xbzu1/1.0/part0_pins.xml
+++ b/xbzu1/1.0/part0_pins.xml
@@ -23,100 +23,100 @@
 <part_info part_name="xczu1cg-sbva484-1-e">
    <pins>
       <!-- MikroE Click Interface -->
-	  <pin index="0"   name="HD_CLICK_SCL_1V8"       iostandard="LVCMOS18" loc="B4"/>
-      <pin index="1"   name="HD_CLICK_SDA_1V8"       iostandard="LVCMOS18" loc="B5"/>
-      <pin index="2"   name="HD_CLICK_INT_1V8"       iostandard="LVCMOS18" loc="A4"/>
-      <pin index="3"   name="HD_CLICK_PWM_1V8"       iostandard="LVCMOS18" loc="A8"/>
-      <pin index="4"   name="HD_CLICK_RST_1V8"       iostandard="LVCMOS18" loc="A9"/>
-      <pin index="5"   name="HD_CLICK_CS0_1V8"       iostandard="LVCMOS18" loc="A2"/>
-      <pin index="6"   name="HD_CLICK_CS1_AN_1V8"    iostandard="LVCMOS18" loc="A3"/>
-      <pin index="7"   name="HD_CLICK_MISO_1V8"      iostandard="LVCMOS18" loc="A6"/>
-      <pin index="8"   name="HD_CLICK_MOSI_1V8"      iostandard="LVCMOS18" loc="A7"/>
-      <pin index="9"   name="HD_CLICK_SCK_1V8"       iostandard="LVCMOS18" loc="B2"/>
-      <pin index="10"  name="HD_CLICK_RX_1V8"        iostandard="LVCMOS18" loc="B1"/>
-      <pin index="11"  name="HD_CLICK_TX_1V8"        iostandard="LVCMOS18" loc="B6"/>
+      <pin index="0"   name ="HD_CLICK_SCL_1V8"      iostandard="LVCMOS18" loc="F8"/>
+      <pin index="1"   name ="HD_CLICK_SDA_1V8"      iostandard="LVCMOS18" loc="F7"/>
+      <pin index="2"   name ="HD_CLICK_INT_1V8"      iostandard="LVCMOS18" loc="E8"/>
+      <pin index="3"   name ="HD_CLICK_PWM_1V8"      iostandard="LVCMOS18" loc="G6"/>
+      <pin index="4"   name ="HD_CLICK_RST_1V8"      iostandard="LVCMOS18" loc="D8"/>
+      <pin index="5"   name ="HD_CLICK_CS0_1V8"      iostandard="LVCMOS18" loc="G7"/>
+      <pin index="6"   name ="HD_CLICK_CS1_AN_1V8"   iostandard="LVCMOS18" loc="G5"/>
+      <pin index="7"   name ="HD_CLICK_MISO_1V8"     iostandard="LVCMOS18" loc="E6"/>
+      <pin index="8"   name ="HD_CLICK_MOSI_1V8"     iostandard="LVCMOS18" loc="E5"/>
+      <pin index="9"   name ="HD_CLICK_SCK_1V8"      iostandard="LVCMOS18" loc="F6"/>
+      <pin index="10"  name ="HD_CLICK_RX_1V8"       iostandard="LVCMOS18" loc="D7"/>
+      <pin index="11"  name ="HD_CLICK_TX_1V8"       iostandard="LVCMOS18" loc="D6"/>
 
       <!-- PUSH BUTTON -->
-      <pin index="12"  name="HD_GPIO_PB1"            iostandard="LVCMOS18" loc="C5"/>
+      <pin index="12"  name ="HD_GPIO_PB1"           iostandard="LVCMOS18" loc="A8"/>
 
       <!-- TRI-COLOR LEDS -->
-      <pin index="13"  name="HD_GPIO_RGB1_B"         iostandard="LVCMOS18" loc="C7"/>
-      <pin index="14"  name="HD_GPIO_RGB1_G"         iostandard="LVCMOS18" loc="C8"/>
-      <pin index="15"  name="HD_GPIO_RGB1_R"         iostandard="LVCMOS18" loc="D1"/>
-      <pin index="16"  name="HP_GPIO_RGB2_B"         iostandard="LVCMOS12" loc="T2"/>
-      <pin index="17"  name="HP_GPIO_RGB2_G"         iostandard="LVCMOS12" loc="T3"/>
-      <pin index="18"  name="HP_GPIO_RGB2_R"         iostandard="LVCMOS12" loc="T4"/>
+      <pin index="13"  name ="HD_GPIO_RGB1_B"        iostandard="LVCMOS18" loc="B5"/>
+      <pin index="14"  name ="HD_GPIO_RGB1_G"        iostandard="LVCMOS18" loc="B6"/>
+      <pin index="15"  name ="HD_GPIO_RGB1_R"        iostandard="LVCMOS18" loc="A7"/>
+      <pin index="16"  name ="HP_GPIO_RGB2_B"        iostandard="LVCMOS12" loc="F4"/>
+      <pin index="17"  name ="HP_GPIO_RGB2_G"        iostandard="LVCMOS12" loc="A2"/>
+      <pin index="18"  name ="HP_GPIO_RGB2_R"        iostandard="LVCMOS12" loc="B4"/>
 
       <!-- TEMPERATURE SENSOR I2C -->
-      <pin index="19"  name="HD_SENSOR_I2C_SCL"      iostandard="LVCMOS18" loc="D2"/>
-      <pin index="20"  name="HD_SENSOR_I2C_SDA"      iostandard="LVCMOS18" loc="D3"/>
+      <pin index="19"  name ="HD_SENSOR_I2C_SCL"     iostandard="LVCMOS18" loc="A6"/>
+      <pin index="20"  name ="HD_SENSOR_I2C_SDA"     iostandard="LVCMOS18" loc="B7"/>
 
       <!-- SYZYGY DNA ALL -->
-      <pin index="21"  name="HD_SYZYGY_SCL_1V8"      iostandard="LVCMOS18" loc="D5"/>
-      <pin index="22"  name="HD_SYZYGY_SDA_1V8"      iostandard="LVCMOS18" loc="D6"/>
+      <pin index="21"  name ="HD_SYZYGY_SCL_1V8"     iostandard="LVCMOS18" loc="B9"/>
+      <pin index="22"  name ="HD_SYZYGY_SDA_1V8"     iostandard="LVCMOS18" loc="A9"/>
 
       <!-- SYZYGY STD PL (J6) -->
-      <pin index="23"  name="HP_DP_07_QBC_N"         iostandard="LVCMOS12" loc="F6"/>
-      <pin index="24"  name="HP_DP_07_QBC_P"         iostandard="LVCMOS12" loc="F7"/>
-      <pin index="25"  name="HP_DP_08_N"             iostandard="LVCMOS12" loc="F8"/>
-      <pin index="26"  name="HP_DP_08_P"             iostandard="LVCMOS12" loc="G1"/>
-      <pin index="27"  name="HP_DP_09_N"             iostandard="LVCMOS12" loc="G2"/>
-      <pin index="28"  name="HP_DP_09_P"             iostandard="LVCMOS12" loc="G4"/>
-      <pin index="29"  name="HP_DP_10_QBC_N"         iostandard="LVCMOS12" loc="G5"/>
-      <pin index="30"  name="HP_DP_10_QBC_P"         iostandard="LVCMOS12" loc="G6"/>
-      <pin index="31"  name="HP_DP_11_GC_N"          iostandard="LVCMOS12" loc="H3"/>
-      <pin index="32"  name="HP_DP_11_GC_P"          iostandard="LVCMOS12" loc="H4"/>
-      <pin index="33"  name="HP_DP_12_GC_N"          iostandard="LVCMOS12" loc="J2"/>
-      <pin index="34"  name="HP_DP_12_GC_P"          iostandard="LVCMOS12" loc="J3"/>
-      <pin index="35"  name="HP_DP_13_GC_N"          iostandard="LVCMOS12" loc="J5"/>
-      <pin index="36"  name="HP_DP_13_GC_P"          iostandard="LVCMOS12" loc="K1"/>
-      <pin index="37"  name="HP_DP_16_QBC_N"         iostandard="LVCMOS12" loc="L3"/>
-      <pin index="38"  name="HP_DP_16_QBC_P"         iostandard="LVCMOS12" loc="L4"/>
-      <pin index="39"  name="HP_DP_17_N"             iostandard="LVCMOS12" loc="M1"/>
-      <pin index="40"  name="HP_DP_17_P"             iostandard="LVCMOS12" loc="M2"/>
-      <pin index="41"  name="HP_DP_18_N"             iostandard="LVCMOS12" loc="M4"/>
-      <pin index="42"  name="HP_DP_18_P"             iostandard="LVCMOS12" loc="M5"/>
-      <pin index="43"  name="HP_DP_19_DBC_N"         iostandard="LVCMOS12" loc="N2"/>
-      <pin index="44"  name="HP_DP_19_DBC_P"         iostandard="LVCMOS12" loc="N3"/>
-      <pin index="45"  name="HP_DP_20_N"             iostandard="LVCMOS12" loc="N4"/>
-      <pin index="46"  name="HP_DP_20_P"             iostandard="LVCMOS12" loc="N5"/>
-      <pin index="47"  name="HP_DP_21_N"             iostandard="LVCMOS12" loc="P1"/>
-      <pin index="48"  name="HP_DP_21_P"             iostandard="LVCMOS12" loc="P3"/>
-      <pin index="49"  name="HP_DP_22_N"             iostandard="LVCMOS12" loc="P5"/>
-      <pin index="50"  name="HP_DP_22_P"             iostandard="LVCMOS12" loc="R1"/>
-      <pin index="51"  name="HP_DP_23_N"             iostandard="LVCMOS12" loc="R3"/>
-      <pin index="52"  name="HP_DP_23_P"             iostandard="LVCMOS12" loc="R4"/>
-      <pin index="53"  name="HP_SE_01"               iostandard="LVCMOS12" loc="U1"/>
-      <pin index="54"  name="HP_SE_02"               iostandard="LVCMOS12" loc="U2"/>
+      <pin index="23"  name ="HP_DP_07_QBC_N"        iostandard="LVCMOS12" loc="P1"/>
+      <pin index="24"  name ="HP_DP_07_QBC_P"        iostandard="LVCMOS12" loc="N2"/>
+      <pin index="25"  name ="HP_DP_08_N"            iostandard="LVCMOS12" loc="N4"/>
+      <pin index="26"  name ="HP_DP_08_P"            iostandard="LVCMOS12" loc="N5"/>
+      <pin index="27"  name ="HP_DP_09_N"            iostandard="LVCMOS12" loc="M1"/>
+      <pin index="28"  name ="HP_DP_09_P"            iostandard="LVCMOS12" loc="M2"/>
+      <pin index="29"  name ="HP_DP_10_QBC_N"        iostandard="LVCMOS12" loc="M4"/>
+      <pin index="30"  name ="HP_DP_10_QBC_P"        iostandard="LVCMOS12" loc="M5"/>
+      <pin index="31"  name ="HP_DP_11_GC_N"         iostandard="LVCMOS12" loc="L1"/>
+      <pin index="32"  name ="HP_DP_11_GC_P"         iostandard="LVCMOS12" loc="L2"/>
+      <pin index="33"  name ="HP_DP_12_GC_N"         iostandard="LVCMOS12" loc="L3"/>
+      <pin index="34"  name ="HP_DP_12_GC_P"         iostandard="LVCMOS12" loc="L4"/>
+      <pin index="35"  name ="HP_DP_13_GC_N"         iostandard="LVCMOS12" loc="J2"/>
+      <pin index="36"  name ="HP_DP_13_GC_P"         iostandard="LVCMOS12" loc="J3"/>
+      <pin index="37"  name ="HP_DP_16_QBC_N"        iostandard="LVCMOS12" loc="H5"/>
+      <pin index="38"  name ="HP_DP_16_QBC_P"        iostandard="LVCMOS12" loc="J5"/>
+      <pin index="39"  name ="HP_DP_17_N"            iostandard="LVCMOS12" loc="G2"/>
+      <pin index="40"  name ="HP_DP_17_P"            iostandard="LVCMOS12" loc="H2"/>
+      <pin index="41"  name ="HP_DP_18_N"            iostandard="LVCMOS12" loc="G4"/>
+      <pin index="42"  name ="HP_DP_18_P"            iostandard="LVCMOS12" loc="H4"/>
+      <pin index="43"  name ="HP_DP_19_DBC_N"        iostandard="LVCMOS12" loc="F1"/>
+      <pin index="44"  name ="HP_DP_19_DBC_P"        iostandard="LVCMOS12" loc="G1"/>
+      <pin index="45"  name ="HP_DP_20_N"            iostandard="LVCMOS12" loc="E3"/>
+      <pin index="46"  name ="HP_DP_20_P"            iostandard="LVCMOS12" loc="E4"/>
+      <pin index="47"  name ="HP_DP_21_N"            iostandard="LVCMOS12" loc="D1"/>
+      <pin index="48"  name ="HP_DP_21_P"            iostandard="LVCMOS12" loc="E1"/>
+      <pin index="49"  name ="HP_DP_22_N"            iostandard="LVCMOS12" loc="C3"/>
+      <pin index="50"  name ="HP_DP_22_P"            iostandard="LVCMOS12" loc="D3"/>
+      <pin index="51"  name ="HP_DP_23_N"            iostandard="LVCMOS12" loc="F2"/>
+      <pin index="52"  name ="HP_DP_23_P"            iostandard="LVCMOS12" loc="F3"/>
+      <pin index="53"  name ="HP_SE_01"              iostandard="LVCMOS12" loc="N3"/>
+      <pin index="54"  name ="HP_SE_02"              iostandard="LVCMOS12" loc="H3"/>
 
       <!-- SYZYGY TRX2 PL (J1) -->
-      <pin index="55"  name="HP_DP_01_DBC_N"         iostandard="LVCMOS12" loc="D7"/>
-      <pin index="56"  name="HP_DP_01_DBC_P"         iostandard="LVCMOS12" loc="D8"/>
-      <pin index="57"  name="HP_DP_02_N"             iostandard="LVCMOS12" loc="E1"/>
-      <pin index="58"  name="HP_DP_02_P"             iostandard="LVCMOS12" loc="E3"/>
-      <pin index="59"  name="HP_DP_03_N"             iostandard="LVCMOS12" loc="E4"/>
-      <pin index="60"  name="HP_DP_03_P"             iostandard="LVCMOS12" loc="E5"/>
-      <pin index="61"  name="HP_DP_04_N"             iostandard="LVCMOS12" loc="E6"/>
-      <pin index="62"  name="HP_DP_04_P"             iostandard="LVCMOS12" loc="E8"/>
-      <pin index="63"  name="HP_DP_05_N"             iostandard="LVCMOS12" loc="F1"/>
-      <pin index="64"  name="HP_DP_05_P"             iostandard="LVCMOS12" loc="F2"/>
-      <pin index="65"  name="HP_DP_06_N"             iostandard="LVCMOS12" loc="F3"/>
-      <pin index="66"  name="HP_DP_06_P"             iostandard="LVCMOS12" loc="F4"/>
-      <pin index="67"  name="HP_DP_11_GC_66_N"       iostandard="LVCMOS12" loc="G7"/>
-      <pin index="68"  name="HP_DP_11_GC_66_P"       iostandard="LVCMOS12" loc="H2"/>
-      <pin index="69"  name="HP_DP_12_GC_66_N"       iostandard="LVCMOS12" loc="H5"/>
-      <pin index="70"  name="HP_DP_12_GC_66_P"       iostandard="LVCMOS12" loc="J1"/>
-      <pin index="71"  name="HP_DP_14_GC_N"          iostandard="LVCMOS12" loc="K3"/>
-      <pin index="72"  name="HP_DP_14_GC_P"          iostandard="LVCMOS12" loc="K4"/>
-      <pin index="73"  name="HP_DP_15_N"             iostandard="LVCMOS12" loc="L1"/>
-      <pin index="74"  name="HP_DP_15_P"             iostandard="LVCMOS12" loc="L2"/>
-      <pin index="75"  name="HP_DP_24_N"             iostandard="LVCMOS12" loc="R5"/>
-      <pin index="76"  name="HP_DP_24_P"             iostandard="LVCMOS12" loc="T1"/>
-
-	  <!-- SYZYGY TRX2 MIO (J2) -->
-      <pin index="77"  name="HD_DP_07_GC_N"          iostandard="LVCMOS18" loc="B7"/>
-      <pin index="78"  name="HD_DP_07_GC_P"          iostandard="LVCMOS18" loc="B9"/>
-      <pin index="79"  name="HD_DP_08_GC_N"          iostandard="LVCMOS18" loc="C2"/>
-      <pin index="80"  name="HD_DP_08_GC_P"          iostandard="LVCMOS18" loc="C3"/>
+      <pin index="55"  name ="HP_DP_01_DBC_N"        iostandard="LVCMOS12" loc="T2"/>
+      <pin index="56"  name ="HP_DP_01_DBC_P"        iostandard="LVCMOS12" loc="T3"/>
+      <pin index="57"  name ="HP_DP_02_N"            iostandard="LVCMOS12" loc="R3"/>
+      <pin index="58"  name ="HP_DP_02_P"            iostandard="LVCMOS12" loc="P3"/>
+      <pin index="59"  name ="HP_DP_03_N"            iostandard="LVCMOS12" loc="U1"/>
+      <pin index="60"  name ="HP_DP_03_P"            iostandard="LVCMOS12" loc="U2"/>
+      <pin index="61"  name ="HP_DP_04_N"            iostandard="LVCMOS12" loc="T4"/>
+      <pin index="62"  name ="HP_DP_04_P"            iostandard="LVCMOS12" loc="R4"/>
+      <pin index="63"  name ="HP_DP_05_N"            iostandard="LVCMOS12" loc="T1"/>
+      <pin index="64"  name ="HP_DP_05_P"            iostandard="LVCMOS12" loc="R1"/>
+      <pin index="65"  name ="HP_DP_06_N"            iostandard="LVCMOS12" loc="R5"/>
+      <pin index="66"  name ="HP_DP_06_P"            iostandard="LVCMOS12" loc="P5"/>
+      <pin index="67"  name ="HP_DP_11_GC_66_N"      iostandard="LVCMOS12" loc="B1"/>
+      <pin index="68"  name ="HP_DP_11_GC_66_P"      iostandard="LVCMOS12" loc="B2"/>
+      <pin index="69"  name ="HP_DP_12_GC_66_N"      iostandard="LVCMOS12" loc="A3"/>
+      <pin index="70"  name ="HP_DP_12_GC_66_P"      iostandard="LVCMOS12" loc="A4"/>
+      <pin index="71"  name ="HP_DP_14_GC_N"         iostandard="LVCMOS12" loc="K3"/>
+      <pin index="72"  name ="HP_DP_14_GC_P"         iostandard="LVCMOS12" loc="K4"/>
+      <pin index="73"  name ="HP_DP_15_N"            iostandard="LVCMOS12" loc="J1"/>
+      <pin index="74"  name ="HP_DP_15_P"            iostandard="LVCMOS12" loc="K1"/>
+      <pin index="75"  name ="HP_DP_24_N"            iostandard="LVCMOS12" loc="C2"/>
+      <pin index="76"  name ="HP_DP_24_P"            iostandard="LVCMOS12" loc="D2"/>
+	  
+  	  <!-- SYZYGY TRX2 MIO (J2) -->
+      <pin index="77"  name ="HD_DP_07_GC_N"         iostandard="LVCMOS18" loc="C5"/>
+      <pin index="78"  name ="HD_DP_07_GC_P"         iostandard="LVCMOS18" loc="D5"/>
+      <pin index="79"  name ="HD_DP_08_GC_N"         iostandard="LVCMOS18" loc="C7"/>
+      <pin index="80"  name ="HD_DP_08_GC_P"         iostandard="LVCMOS18" loc="C8"/>
    </pins>
 </part_info>

--- a/xbzu1/1.0/preset.xml
+++ b/xbzu1/1.0/preset.xml
@@ -30,7 +30,9 @@
             
             <user_parameter name="CONFIG.PSU__USE__IRQ0" value="0"/>
             <user_parameter name="CONFIG.PSU__USE__IRQ1" value="0"/>
-            <user_parameter name="CONFIG.PSU__USE__M_AXI_GP0" value="0"/>
+            <user_parameter name="CONFIG.PSU__USE__M_AXI_GP0" value="1"/>
+            <user_parameter name="CONFIG.PSU__USE__M_AXI_GP1" value="1"/>
+            <user_parameter name="CONFIG.PSU__USE__M_AXI_GP2" value="0"/>
             
             <user_parameter name="CONFIG.PSU_BANK_0_IO_STANDARD" value="LVCMOS18"/>
             <user_parameter name="CONFIG.PSU_BANK_1_IO_STANDARD" value="LVCMOS18"/>
@@ -244,8 +246,8 @@
             <user_parameter name="CONFIG.PSU__NAND__READY0_BUSY__ENABLE" value="0"/>
             <user_parameter name="CONFIG.PSU__NAND__READY1_BUSY__ENABLE" value="0"/>
 
-            <user_parameter name="CONFIG.PSU__NUM_FABRIC_RESETS" value="0"/>
-            <user_parameter name="CONFIG.PSU__USE__FABRIC__RST" value="0"/>
+            <user_parameter name="CONFIG.PSU__NUM_FABRIC_RESETS" value="1"/>
+            <user_parameter name="CONFIG.PSU__USE__FABRIC__RST" value="1"/>
 
             <user_parameter name="CONFIG.PSU__PL_CLK0_BUF" value="TRUE"/>
             <user_parameter name="CONFIG.PSU__PL_CLK1_BUF" value="FALSE"/>


### PR DESCRIPTION
corrected a bunch of pin locs. Turned on Fabric reset and AXI_GP0 and AXI_GP1. Removed pin definition from UART component, which isn't needed since the definitions are in the interface.