### PR TITLE
Update 220318 to ZUBoard BDF

### DIFF
--- a/zub1cg/1.0/board.xml
+++ b/zub1cg/1.0/board.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?> 
-<!DOCTYPE board SYSTEM "C:/Xilinx/Vivado/2021.2/data/boards/board_schemas/current/board.dtd">
+<!--<!DOCTYPE board SYSTEM "C:/Xilinx/Vivado/2021.2/data/boards/board_schemas/current/board.dtd">-->
 <!-- -->
 <!--   ** **        **          **  ****      **  **********  ********** ®   
       **   **        **        **   ** **     **  **              **
@@ -203,7 +203,7 @@
                     <pin_map port_index="0" component_pin="HD_CLICK_SCK_1V8"/> 
                   </pin_maps>
                 </port_map>
-                <port_map logical_port="SS_I" physical_port="HD_CLICK_CS0_1V8" dir="in">
+                <port_map logical_port="SS_I" physical_port="spi_ss_i" dir="in">
                   <pin_maps>
                     <pin_map port_index="0" component_pin="HD_CLICK_CS0_1V8"/> 
                   </pin_maps>

--- a/zub1cg/1.0/board.xml
+++ b/zub1cg/1.0/board.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?> 
-<!--<!DOCTYPE board SYSTEM "C:/Xilinx/Vivado/2021.2/data/boards/board_schemas/current/board.dtd">-->
+<!DOCTYPE board SYSTEM "C:/Xilinx/Vivado/2021.2/data/boards/board_schemas/current/board.dtd">
+<!-- -->
 <!--   ** **        **          **  ****      **  **********  ********** ®   
       **   **        **        **   ** **     **  **              **
      **     **        **      **    **  **    **  **              **
@@ -50,6 +51,34 @@
 
    <jumpers>
    </jumpers>
+     
+   <data_properties>
+      <data_property_group name="OPERATING_CONDITIONS">
+        <data_property_group name="SUPPLY_CURRENT_BUDGET">
+          <data_property name="VCCINT"     value="3"/>
+		  <!--
+          <data_property name="VCCINT_IO"  value="7.38"/>
+          <data_property name="VCCBRAM"    value="1.62"/>
+          <data_property name="VCCAUX"     value="1.19"/>
+          <data_property name="VCCAUX_IO"  value="0.056"/>
+          <data_property name="VCCO18"     value="0.014"/>
+          <data_property name="VCC_IO_HBM" value="3.84"/>
+          <data_property name="VCC_HBM"    value="4.16"/>
+          <data_property name="VCCAUX_HBM" value="0.2"/>
+          <data_property name="MGTYVCCAUX" value="0.144"/>
+          <data_property name="MGTYAVCC"   value="1.4"/>
+          <data_property name="MGTYAVTT"   value="3.6"/>
+          <data_property name="VCCADC"     value="0.02"/>
+		  -->
+        </data_property_group>
+        <data_property name="THETAJA"             value="0.75"/>
+        <data_property name="AMBIENT_TEMP"        value="25"/>
+        <data_property name="DESIGN_POWER_BUDGET" value="45"/>
+        <data_property name="HEATSINK"            value="medium"/>
+        <data_property name="BOARD_TEMP"          value="40"/>
+        <data_property name="BOARD_LAYERS"        value="12to15"/>
+    </data_property_group>
+  </data_properties>
 
    <components>   
 
@@ -66,8 +95,8 @@
             </interface>
 
             <!-- MikroE Click I2C -->
-    	    <interface mode="master" name="click_i2c_pl" type="xilinx.com:interface:iic_rtl:1.0" of_component="click_i2c_pl">
-	          <preferred_ips>
+             <interface mode="master" name="click_i2c_pl" type="xilinx.com:interface:iic_rtl:1.0" of_component="click_i2c_pl">
+              <preferred_ips>
                 <preferred_ip vendor="xilinx.com" library="ip" name="axi_iic" order="0"/>
               </preferred_ips>
               <port_maps>
@@ -122,7 +151,7 @@
                 </port_map>
               </port_maps>
             </interface>
-			
+               
             <!-- MikroE Click SPI -->
             <interface mode="master" name="click_spi_pl" type="xilinx.com:interface:spi_rtl:1.0" of_component="click_spi_pl" preset_proc="click_spi_pl_preset">
               <preferred_ips>
@@ -198,23 +227,23 @@
             </interface>      
 
             <!-- MikroE Click UART -->
-			<interface mode="master" name="click_uart_pl" type="xilinx.com:interface:uart_rtl:1.0" of_component="click_uart_pl">
-			  <preferred_ips>
-				<preferred_ip vendor="xilinx.com" library="ip" name="axi_uartlite" order="0"/>
-			  </preferred_ips>
-			  <port_maps>
-				<port_map logical_port="TxD" physical_port="rs232_uart_txd" dir="out">
-				  <pin_maps>
-					<pin_map port_index="0" component_pin="HD_CLICK_TX_1V8"/>
-				  </pin_maps>
-				</port_map>
-				<port_map logical_port="RxD" physical_port="rs232_uart_rxd" dir="in">
-				  <pin_maps>
-					<pin_map port_index="0" component_pin="HD_CLICK_RX_1V8"/>
-				  </pin_maps>
-				</port_map>
-			  </port_maps>
-			</interface>
+            <interface mode="master" name="click_uart_pl" type="xilinx.com:interface:uart_rtl:1.0" of_component="click_uart_pl">
+              <preferred_ips>
+               <preferred_ip vendor="xilinx.com" library="ip" name="axi_uartlite" order="0"/>
+              </preferred_ips>
+               <port_maps>
+                 <port_map logical_port="TxD" physical_port="rs232_uart_txd" dir="out">
+                  <pin_maps>
+                     <pin_map port_index="0" component_pin="HD_CLICK_TX_1V8"/>
+                  </pin_maps>
+                 </port_map>
+                 <port_map logical_port="RxD" physical_port="rs232_uart_rxd" dir="in">
+                   <pin_maps>
+                      <pin_map port_index="0" component_pin="HD_CLICK_RX_1V8"/>
+                   </pin_maps>
+                 </port_map>
+               </port_maps>
+            </interface>
 
             <!-- PUSH BUTTON -->
             <interface mode="master" name="push_button_1bit" type="xilinx.com:interface:gpio_rtl:1.0" of_component="push_button_1bit" preset_proc="push_button_1bit_preset">
@@ -264,8 +293,8 @@
             </interface>
 
             <!-- TEMPERATURE SENSOR I2C -->
-    	    <interface mode="master" name="tempsensor_i2c_pl" type="xilinx.com:interface:iic_rtl:1.0" of_component="tempsensor_i2c_pl">
-	          <preferred_ips>
+             <interface mode="master" name="tempsensor_i2c_pl" type="xilinx.com:interface:iic_rtl:1.0" of_component="tempsensor_i2c_pl">
+              <preferred_ips>
                 <preferred_ip vendor="xilinx.com" library="ip" name="axi_iic" order="0"/>
               </preferred_ips>
               <port_maps>
@@ -303,8 +332,8 @@
             </interface>
 
             <!-- SYZYGY DNA I2C -->
-    	    <interface mode="master" name="syzygydna_i2c_pl" type="xilinx.com:interface:iic_rtl:1.0" of_component="syzygydna_i2c_pl">
-	          <preferred_ips>
+            <interface mode="master" name="syzygydna_i2c_pl" type="xilinx.com:interface:iic_rtl:1.0" of_component="syzygydna_i2c_pl">
+              <preferred_ips>
                 <preferred_ip vendor="xilinx.com" library="ip" name="axi_iic" order="0"/>
               </preferred_ips>
               <port_maps>
@@ -343,11 +372,11 @@
 
             <!-- SYZYGY STD PL (J6) -->
 
-            <!-- SYZYGY TRX2 PL (J1) -->
+            <!-- SYZYGY TXR2 PL (J1) -->
 
-	  	    <!-- SYZYGY TRX2 MIO (J2) -->
+                <!-- SYZYGY TXR2 MIO (J2) -->
 
-			</interfaces> 
+         </interfaces> 
       </component>
 
       <!-- ZU+ PS Fixed I/O -->
@@ -401,72 +430,150 @@
       </component>
 
       <!-- SYZYGY STD PL (J6) -->
-
-      <!-- SYZYGY TRX2 PL (J1) -->
-
-	  <!-- SYZYGY TRX2 MIO (J2) -->
-
-	  </components>
+      <component name="szg_std_J6" type="connector" sub_type="som" display_name="Syzygy PL J6 (STD)">
+        <pins>
+          <pin index="0"  name="szg_std_J6_s0_d0p"   ></pin> 
+          <pin index="1"  name="szg_std_J6_s1_d1p"   ></pin> 
+          <pin index="2"  name="szg_std_J6_s2_d0n"   ></pin> 
+          <pin index="3"  name="szg_std_J6_s3_d1n"   ></pin> 
+          <pin index="4"  name="szg_std_J6_s4_d2p"   ></pin> 
+          <pin index="5"  name="szg_std_J6_s5_d3p"   ></pin> 
+          <pin index="6"  name="szg_std_J6_s6_d2n"   ></pin> 
+          <pin index="7"  name="szg_std_J6_s7_d3n"   ></pin> 
+          <pin index="8"  name="szg_std_J6_s8_d4p"   ></pin> 
+          <pin index="9"  name="szg_std_J6_s9_d5p"   ></pin> 
+          <pin index="10" name="szg_std_J6_s10_d4n"  ></pin> 
+          <pin index="11" name="szg_std_J6_s11_d5n"  ></pin> 
+          <pin index="12" name="szg_std_J6_s12_d6p"  ></pin> 
+          <pin index="13" name="szg_std_J6_s13_d7p"  ></pin> 
+          <pin index="14" name="szg_std_J6_s14_d6n"  ></pin> 
+          <pin index="15" name="szg_std_J6_s15_d7n"  ></pin> 
+          <pin index="16" name="szg_std_J6_s16_d8p"  ></pin> 
+          <pin index="17" name="szg_std_J6_s17_d9p"  ></pin> 
+          <pin index="18" name="szg_std_J6_s18_d8n"  ></pin> 
+          <pin index="19" name="szg_std_J6_s19_d9n"  ></pin> 
+          <pin index="20" name="szg_std_J6_s20_d10p" ></pin> 
+          <pin index="21" name="szg_std_J6_s21_d11p" ></pin> 
+          <pin index="22" name="szg_std_J6_s22_d10n" ></pin> 
+          <pin index="23" name="szg_std_J6_s23_d11n" ></pin> 
+          <pin index="24" name="szg_std_J6_s24_d12p" ></pin> 
+          <pin index="25" name="szg_std_J6_s25_d13p" ></pin> 
+          <pin index="26" name="szg_std_J6_s26_d12n" ></pin> 
+          <pin index="27" name="szg_std_J6_s27_d13n" ></pin> 
+          <pin index="28" name="szg_std_J6_p2c_clkp" ></pin> 
+          <pin index="29" name="szg_std_J6_c2p_clkp" ></pin> 
+          <pin index="30" name="szg_std_J6_p2c_clkn" ></pin> 
+          <pin index="31" name="szg_std_J6_c2p_clkn" ></pin> 
+        </pins>
+      </component>
+       
+      <!-- SYZYGY TXR2 PL (J1) -->
+      <component name="szg_txr2_pl_J1" type="connector" sub_type="som" display_name="Syzygy PL J1 (TXR2)">
+        <pins>
+          <pin index="0"  name="szg_txr2_pl_J1_s0_d0p"   ></pin> 
+          <pin index="2"  name="szg_txr2_pl_J1_s1_d0n"   ></pin> 
+          <pin index="1"  name="szg_txr2_pl_J1_s2_d1p"   ></pin> 
+          <pin index="5"  name="szg_txr2_pl_J1_s3_d2p"   ></pin> 
+          <pin index="6"  name="szg_txr2_pl_J1_s4_d1n"   ></pin> 
+          <pin index="7"  name="szg_txr2_pl_J1_s5_d2n"   ></pin> 
+          <pin index="8"  name="szg_txr2_pl_J1_s6_d3p"   ></pin> 
+          <pin index="9"  name="szg_txr2_pl_J1_s7_d4p"   ></pin> 
+          <pin index="10" name="szg_txr2_pl_J1_s8_d3n"   ></pin> 
+          <pin index="11" name="szg_txr2_pl_J1_s9_d4n"   ></pin> 
+          <pin index="12" name="szg_txr2_pl_J1_s10_d5p"  ></pin> 
+          <pin index="13" name="szg_txr2_pl_J1_s11_d6p"  ></pin> 
+          <pin index="14" name="szg_txr2_pl_J1_s12_d5n"  ></pin> 
+          <pin index="15" name="szg_txr2_pl_J1_s13_d6n"  ></pin> 
+          <pin index="16" name="szg_txr2_pl_J1_s14_d7p"  ></pin> 
+          <pin index="17" name="szg_txr2_pl_J1_s15_d8p"  ></pin> 
+          <pin index="18" name="szg_txr2_pl_J1_s16_d7n"  ></pin> 
+          <pin index="18" name="szg_txr2_pl_J1_s17_d8n"  ></pin> 
+          <pin index="19" name="szg_txr2_pl_J1_p2c_clkp" ></pin> 
+          <pin index="20" name="szg_txr2_pl_J1_c2p_clkp" ></pin> 
+          <pin index="21" name="szg_txr2_pl_J1_p2c_clkn" ></pin> 
+          <pin index="22" name="szg_txr2_pl_J1_c2p_clkn" ></pin> 
+        </pins>
+      </component>
+       
+       <!-- SYZYGY TXR2 MIO (J2) -->
+      <component name="szg_txr2_mio_J2" type="connector" sub_type="som" display_name="Syzygy MIO J2 (TXR2)">
+        <pins>
+          <pin index="0"  name="szg_txr2_mio_J2_p2c_clkp" ></pin> 
+          <pin index="1"  name="szg_txr2_mio_J2_c2p_clkp" ></pin> 
+          <pin index="2"  name="szg_txr2_mio_J2_p2c_clkn" ></pin> 
+          <pin index="3"  name="szg_txr2_mio_J2_c2p_clkn" ></pin> 
+        </pins>
+      </component>
+   </components>
 
    <jtag_chains>
       <jtag_chain name="chain1">
           <position name="0" component="part0"/>
       </jtag_chain>
    </jtag_chains>
-
+     
    <connections>
-   <!-- MikroE Click I2C -->
-   <connection name="part0_click_i2c_pl" component1="part0" component2="click_i2c_pl">
-     <connection_map name="part0_click_i2c_pl" typical_delay="5" c1_st_index="0" c1_end_index="1" c2_st_index="0" c2_end_index="1"/>
-   </connection>
-
-   <!-- MikroE Click Interrupt -->
-
-   <!-- MikroE Click PWM -->
-
-   <!-- MikroE Click Reset -->
-   <connection name="part0_click_reset_pl" component1="part0" component2="click_reset_pl">
-     <connection_map name="part0_click_reset_pl" typical_delay="5" c1_st_index="4" c1_end_index="4" component2="click_reset_pl" c2_st_index="0" c2_end_index="0"/>
-   </connection>
-
-   <!-- MikroE Click SPI -->
-   <connection name="part0_click_spi_pl" component1="part0" component2="click_spi_pl">
-     <connection_map name="part0_click_spi_pl_1" c1_st_index="5" c1_end_index="9" c2_st_index="0" c2_end_index="4"/>
-   </connection>
-
-   <!-- MikroE Click UART -->
-   <connection name="part0_click_uart_pl" component1="part0" component2="click_uart_pl">
-      <connection_map name="part0_click_uart_pl" typical_delay="5" c1_st_index="10" c1_end_index="11" c2_st_index="0" c2_end_index="1"/>
-   </connection>
-
-   <!-- PUSH BUTTON -->
-   <connection name="part0_push_button_1bit" component1="part0" component2="push_button_1bit">
-     <connection_map name="part0_push_button_1bit_1" typical_delay="5" c1_st_index="12" c1_end_index="12" c2_st_index="0" c2_end_index="0"/>
-   </connection>
-
-   <!-- TRI-COLOR LEDS -->
-    <connection name="part0_rgb1_led_3bits" component1="part0" component2="rgb1_led_3bits">
-      <connection_map name="part0_rgb1_led_3bits" typical_delay="5" c1_st_index="13" c1_end_index="15" c2_st_index="0" c2_end_index="2"/>
-    </connection>
-    <connection name="part0_rgb2_led_3bits" component1="part0" component2="rgb2_led_3bits">
-      <connection_map name="part0_rgb2_led_3bits" typical_delay="5" c1_st_index="16" c1_end_index="18" c2_st_index="0" c2_end_index="2"/>
-    </connection>
-
-   <!-- TEMPERATURE SENSOR I2C -->
-   <connection name="part0_tempsensor_i2c_pl" component1="part0" component2="tempsensor_i2c_pl">
-     <connection_map name="part0_tempsensor_i2c_pl" typical_delay="5" c1_st_index="19" c1_end_index="20" c2_st_index="0" c2_end_index="1"/>
-   </connection>
-
-   <!-- SYZYGY DNA I2C -->
-   <connection name="part0_syzygydna_i2c_pl" component1="part0" component2="syzygydna_i2c_pl">
-     <connection_map name="part0_syzygydna_i2c_pl" typical_delay="5" c1_st_index="21" c1_end_index="22" c2_st_index="0" c2_end_index="1"/>
-   </connection>
-
-   <!-- SYZYGY STD PL (J6) -->
-
-   <!-- SYZYGY TRX2 PL (J1) -->
-
-   <!-- SYZYGY TRX2 MIO (J2) -->
+     <!-- MikroE Click I2C -->
+     <connection name="part0_click_i2c_pl" component1="part0" component2="click_i2c_pl">
+       <connection_map name="part0_click_i2c_pl" typical_delay="5" c1_st_index="0" c1_end_index="1" c2_st_index="0" c2_end_index="1"/>
+     </connection>
+   
+     <!-- MikroE Click Interrupt -->
+   
+     <!-- MikroE Click PWM -->
+   
+     <!-- MikroE Click Reset -->
+     <connection name="part0_click_reset_pl" component1="part0" component2="click_reset_pl">
+       <connection_map name="part0_click_reset_pl" typical_delay="5" c1_st_index="4" c1_end_index="4" component2="click_reset_pl" c2_st_index="0" c2_end_index="0"/>
+     </connection>
+   
+     <!-- MikroE Click SPI -->
+     <connection name="part0_click_spi_pl" component1="part0" component2="click_spi_pl">
+       <connection_map name="part0_click_spi_pl_1" c1_st_index="5" c1_end_index="9" c2_st_index="0" c2_end_index="4"/>
+     </connection>
+   
+     <!-- MikroE Click UART -->
+     <connection name="part0_click_uart_pl" component1="part0" component2="click_uart_pl">
+        <connection_map name="part0_click_uart_pl" typical_delay="5" c1_st_index="10" c1_end_index="11" c2_st_index="0" c2_end_index="1"/>
+     </connection>
+   
+     <!-- PUSH BUTTON -->
+     <connection name="part0_push_button_1bit" component1="part0" component2="push_button_1bit">
+       <connection_map name="part0_push_button_1bit_1" typical_delay="5" c1_st_index="12" c1_end_index="12" c2_st_index="0" c2_end_index="0"/>
+     </connection>
+   
+     <!-- TRI-COLOR LEDS -->
+     <connection name="part0_rgb1_led_3bits" component1="part0" component2="rgb1_led_3bits">
+       <connection_map name="part0_rgb1_led_3bits" typical_delay="5" c1_st_index="13" c1_end_index="15" c2_st_index="0" c2_end_index="2"/>
+     </connection>
+     <connection name="part0_rgb2_led_3bits" component1="part0" component2="rgb2_led_3bits">
+       <connection_map name="part0_rgb2_led_3bits" typical_delay="5" c1_st_index="16" c1_end_index="18" c2_st_index="0" c2_end_index="2"/>
+     </connection>
+   
+     <!-- TEMPERATURE SENSOR I2C -->
+     <connection name="part0_tempsensor_i2c_pl" component1="part0" component2="tempsensor_i2c_pl">
+       <connection_map name="part0_tempsensor_i2c_pl" typical_delay="5" c1_st_index="19" c1_end_index="20" c2_st_index="0" c2_end_index="1"/>
+     </connection>
+   
+     <!-- SYZYGY DNA I2C -->
+     <connection name="part0_syzygydna_i2c_pl" component1="part0" component2="syzygydna_i2c_pl">
+       <connection_map name="part0_syzygydna_i2c_pl" typical_delay="5" c1_st_index="21" c1_end_index="22" c2_st_index="0" c2_end_index="1"/>
+     </connection>
+   
+     <!-- SYZYGY STD PL (J6) -->
+     <connection name="part0_szg_std_J6_connector" component1="part0" component2="szg_std_J6">   
+       <connection_map name="part0_szg_std_J6_map" typical_delay="5" c1_st_index="23" c1_end_index="54" c2_st_index="0" c2_end_index="31" />
+     </connection> 
+     
+     <!-- SYZYGY TXR2 PL (J1) -->
+     <connection name="part0_szg_txr2_pl_J1_connector" component1="part0" component2="szg_txr2_pl_J1">   
+       <connection_map name="part0_szg_txr2_pl_J1_map" typical_delay="5" c1_st_index="55" c1_end_index="76" c2_st_index="0" c2_end_index="21" />
+     </connection> 
+   
+     <!-- SYZYGY TXR2 MIO (J2) -->
+     <connection name="part0_szg_txr2_mio_J2_connector" component1="part0" component2="szg_txr2_mio_J2">   
+       <connection_map name="part0_szg_txr2_mio_J2_map" typical_delay="5" c1_st_index="77" c1_end_index="80" c2_st_index="0" c2_end_index="3" />
+     </connection> 
 
    </connections> 
  

--- a/zub1cg/1.0/part0_pins.xml
+++ b/zub1cg/1.0/part0_pins.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?> 
-<!DOCTYPE part_info SYSTEM "C:/Xilinx/Vivado/2021.2/data/boards/board_schemas/current/part0_pins.dtd">
+<!--<!DOCTYPE part_info SYSTEM "C:/Xilinx/Vivado/2021.2/data/boards/board_schemas/current/part0_pins.dtd">-->
 <!-- -->
 <!--   ** **        **          **  ****      **  **********  ********** ®   
       **   **        **        **   ** **     **  **              **

--- a/zub1cg/1.0/part0_pins.xml
+++ b/zub1cg/1.0/part0_pins.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?> 
-<!--<!DOCTYPE part_info SYSTEM "C:/Xilinx/Vivado/2021.2/data/boards/board_schemas/current/part0_pins.dtd">-->
+<!DOCTYPE part_info SYSTEM "C:/Xilinx/Vivado/2021.2/data/boards/board_schemas/current/part0_pins.dtd">
+<!-- -->
 <!--   ** **        **          **  ****      **  **********  ********** ®   
       **   **        **        **   ** **     **  **              **
      **     **        **      **    **  **    **  **              **
@@ -89,7 +90,7 @@
       <pin index="53"  name ="HP_SE_01"              iostandard="LVCMOS12" loc="N3"/>
       <pin index="54"  name ="HP_SE_02"              iostandard="LVCMOS12" loc="H3"/>
 
-      <!-- SYZYGY TRX2 PL (J1) -->
+      <!-- SYZYGY TXR2 PL (J1) -->
       <pin index="55"  name ="HP_DP_01_DBC_N"        iostandard="LVCMOS12" loc="T2"/>
       <pin index="56"  name ="HP_DP_01_DBC_P"        iostandard="LVCMOS12" loc="T3"/>
       <pin index="57"  name ="HP_DP_02_N"            iostandard="LVCMOS12" loc="R3"/>
@@ -113,7 +114,7 @@
       <pin index="75"  name ="HP_DP_24_N"            iostandard="LVCMOS12" loc="C2"/>
       <pin index="76"  name ="HP_DP_24_P"            iostandard="LVCMOS12" loc="D2"/>
 	  
-  	  <!-- SYZYGY TRX2 MIO (J2) -->
+  	  <!-- SYZYGY TXR2 MIO (J2) -->
       <pin index="77"  name ="HD_DP_07_GC_N"         iostandard="LVCMOS18" loc="C5"/>
       <pin index="78"  name ="HD_DP_07_GC_P"         iostandard="LVCMOS18" loc="D5"/>
       <pin index="79"  name ="HD_DP_08_GC_N"         iostandard="LVCMOS18" loc="C7"/>

--- a/zub1cg/1.0/preset.xml
+++ b/zub1cg/1.0/preset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?> 
-<!--<!DOCTYPE ip_presets SYSTEM "C:/Xilinx/Vivado/2021.1/data/boards/board_schemas/current/preset.dtd">-->
+<!DOCTYPE ip_presets SYSTEM "C:/Xilinx/Vivado/2021.1/data/boards/board_schemas/current/preset.dtd">
+<!-- -->
 <!--   ** **        **          **  ****      **  **********  ********** ®   
       **   **        **        **   ** **     **  **              **
      **     **        **      **    **  **    **  **              **

--- a/zub1cg/1.0/preset.xml
+++ b/zub1cg/1.0/preset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?> 
-<!DOCTYPE ip_presets SYSTEM "C:/Xilinx/Vivado/2021.1/data/boards/board_schemas/current/preset.dtd">
+<!--<!DOCTYPE ip_presets SYSTEM "C:/Xilinx/Vivado/2021.1/data/boards/board_schemas/current/preset.dtd">-->
 <!-- -->
 <!--   ** **        **          **  ****      **  **********  ********** ®   
       **   **        **        **   ** **     **  **              **


### PR DESCRIPTION
Added operating conditions; removed useless parameters; added Syzygy; corrected TRX to TXR; made whitespace consistent; made smaller photo for easier zipping.