### PR TITLE
Adding workaround constraints

### DIFF
--- a/zub1cg/1.0/ZUBoard_temp.xdc
+++ b/zub1cg/1.0/ZUBoard_temp.xdc
@@ -1,0 +1,5 @@
+set_property PACKAGE_PIN G7 [get_ports {click_spi_pl_ss_io[0]}]
+set_property PACKAGE_PIN G5 [get_ports {click_spi_pl_ss_io[1]}]
+
+set_property IOSTANDARD LVCMOS18 [get_ports {click_spi_pl_ss_io[1]}]
+set_property IOSTANDARD LVCMOS18 [get_ports {click_spi_pl_ss_io[0]}]


### PR DESCRIPTION
These are required for the 2021.2.1 bug in AXI_QSPI with the SPI peripheral on the Click Site