### PR TITLE
ultrazed: fix sdio clocks to avoid conflicts with dp

### DIFF
--- a/ultrazed_3eg_iocc/1.2/preset.xml
+++ b/ultrazed_3eg_iocc/1.2/preset.xml
@@ -148,7 +148,9 @@
 <user_parameter name="CONFIG.PSU__CRL_APB__CPU_R5_CTRL__FREQMHZ" value="500"/>
 <user_parameter name="CONFIG.PSU__CRL_APB__QSPI_REF_CTRL__SRCSEL" value="IOPLL"/>
 <user_parameter name="CONFIG.PSU__CRL_APB__QSPI_REF_CTRL__FREQMHZ" value="125"/>
-<user_parameter name="CONFIG.PSU__CRL_APB__SDIO1_REF_CTRL__SRCSEL" value="RPLL"/>
+<user_parameter name="CONFIG.PSU__CRL_APB__SDIO0_REF_CTRL__SRCSEL" value="IOPLL"/>
+<user_parameter name="CONFIG.PSU__CRL_APB__SDIO0_REF_CTRL__FREQMHZ" value="200"/>
+<user_parameter name="CONFIG.PSU__CRL_APB__SDIO1_REF_CTRL__SRCSEL" value="IOPLL"/>
 <user_parameter name="CONFIG.PSU__CRL_APB__SDIO1_REF_CTRL__FREQMHZ" value="200"/>
 <user_parameter name="CONFIG.PSU__CRL_APB__UART0_REF_CTRL__SRCSEL" value="IOPLL"/>
 <user_parameter name="CONFIG.PSU__CRL_APB__UART0_REF_CTRL__FREQMHZ" value="100"/>

--- a/ultrazed_3eg_pciecc/1.3/preset.xml
+++ b/ultrazed_3eg_pciecc/1.3/preset.xml
@@ -159,7 +159,9 @@
 <user_parameter name="CONFIG.PSU__CRL_APB__CPU_R5_CTRL__FREQMHZ" value="500"/>
 <user_parameter name="CONFIG.PSU__CRL_APB__QSPI_REF_CTRL__SRCSEL" value="IOPLL"/>
 <user_parameter name="CONFIG.PSU__CRL_APB__QSPI_REF_CTRL__FREQMHZ" value="125"/>
-<user_parameter name="CONFIG.PSU__CRL_APB__SDIO1_REF_CTRL__SRCSEL" value="RPLL"/>
+<user_parameter name="CONFIG.PSU__CRL_APB__SDIO0_REF_CTRL__SRCSEL" value="IOPLL"/>
+<user_parameter name="CONFIG.PSU__CRL_APB__SDIO0_REF_CTRL__FREQMHZ" value="200"/>
+<user_parameter name="CONFIG.PSU__CRL_APB__SDIO1_REF_CTRL__SRCSEL" value="IOPLL"/>
 <user_parameter name="CONFIG.PSU__CRL_APB__SDIO1_REF_CTRL__FREQMHZ" value="200"/>
 <user_parameter name="CONFIG.PSU__CRL_APB__UART0_REF_CTRL__SRCSEL" value="IOPLL"/>
 <user_parameter name="CONFIG.PSU__CRL_APB__UART0_REF_CTRL__FREQMHZ" value="100"/>

--- a/ultrazed_7ev_cc/1.5/preset.xml
+++ b/ultrazed_7ev_cc/1.5/preset.xml
@@ -176,7 +176,9 @@
 <user_parameter name="CONFIG.PSU__CRL_APB__CPU_R5_CTRL__FREQMHZ" value="500"/>
 <user_parameter name="CONFIG.PSU__CRL_APB__QSPI_REF_CTRL__SRCSEL" value="IOPLL"/>
 <user_parameter name="CONFIG.PSU__CRL_APB__QSPI_REF_CTRL__FREQMHZ" value="125"/>
-<user_parameter name="CONFIG.PSU__CRL_APB__SDIO1_REF_CTRL__SRCSEL" value="RPLL"/>
+<user_parameter name="CONFIG.PSU__CRL_APB__SDIO0_REF_CTRL__SRCSEL" value="IOPLL"/>
+<user_parameter name="CONFIG.PSU__CRL_APB__SDIO0_REF_CTRL__FREQMHZ" value="200"/>
+<user_parameter name="CONFIG.PSU__CRL_APB__SDIO1_REF_CTRL__SRCSEL" value="IOPLL"/>
 <user_parameter name="CONFIG.PSU__CRL_APB__SDIO1_REF_CTRL__FREQMHZ" value="200"/>
 <user_parameter name="CONFIG.PSU__CRL_APB__UART0_REF_CTRL__SRCSEL" value="IOPLL"/>
 <user_parameter name="CONFIG.PSU__CRL_APB__UART0_REF_CTRL__FREQMHZ" value="100"/>


### PR DESCRIPTION
As the DP audio clock is also generated by RPLL, there was a conflict preventing the DP audio clock to be correct:
[   22.952726] xilinx-dp-snd-codec
fd4a0000.display:zynqmp_dp_snd_codec0: ASoC: error at
snd_soc_dai_hw_params on xilinx-dp-snd-codec-dai: -22
[   22.965251]  xilinx-dp0: ASoC: soc_pcm_hw_params() failed (-22)
[   22.977905] xilinx-dp-snd-codec
fd4a0000.display:zynqmp_dp_snd_codec0: aud_clk offset is higher: -142006